### PR TITLE
fix: share button layout breaking title on mobile

### DIFF
--- a/src/components/PointsResult.tsx
+++ b/src/components/PointsResult.tsx
@@ -188,7 +188,7 @@ export function PointsResult({ data }: PointsResultProps) {
   return (
     <Card ref={resultRef}>
       <CardHeader>
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <CardTitle className="text-xl text-primary">{t('result.title')}</CardTitle>
           <div className="flex gap-2 no-print">
             <div className="relative">
@@ -202,7 +202,7 @@ export function PointsResult({ data }: PointsResultProps) {
                 {t('result.shareResult') || 'Share'}
               </Button>
               {shareTooltip && (
-                <div className="absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-foreground px-2 py-1 text-xs text-background shadow">
+                <div className="absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-foreground px-2 py-1 text-xs text-background shadow z-10">
                   {shareTooltip}
                 </div>
               )}


### PR DESCRIPTION
## Problem
Share button added in previous commit causes the '결과' title to be cut off on mobile (see screenshot in issue).

## Fix
- Mobile: title and buttons stack vertically (\lex-col\)
- Desktop (sm+): side-by-side as before (\sm:flex-row sm:justify-between\)
- Added \z-10\ to tooltip to prevent overlap

## Before/After
- Before: 결 자만 보이고 나머지 잘림
- After: 타이틀 풀 표시, 버튼은 아래로