### PR TITLE
feat: SEO guide pages + react-router + GEO optimization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
                 "react-error-boundary": "^6.0.0",
                 "react-hook-form": "^7.54.2",
                 "react-resizable-panels": "^2.1.7",
+                "react-router-dom": "^7.15.0",
                 "react-to-print": "^3.1.1",
                 "recharts": "^2.15.1",
                 "sonner": "^2.0.1",
@@ -4113,6 +4114,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/cookie": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6126,6 +6140,44 @@
                 "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
             }
         },
+        "node_modules/react-router": {
+            "version": "7.15.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+            "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
+            "license": "MIT",
+            "dependencies": {
+                "cookie": "^1.0.1",
+                "set-cookie-parser": "^2.6.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=18",
+                "react-dom": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-router-dom": {
+            "version": "7.15.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
+            "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
+            "license": "MIT",
+            "dependencies": {
+                "react-router": "7.15.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=18",
+                "react-dom": ">=18"
+            }
+        },
         "node_modules/react-smooth": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
@@ -6319,6 +6371,12 @@
             "bin": {
                 "semver": "bin/semver.js"
             }
+        },
+        "node_modules/set-cookie-parser": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+            "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+            "license": "MIT"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "dev": "vite",
         "kill": "fuser -k 5000/tcp",
-        "build": "tsc -b --noCheck && vite build",
+        "build": "tsc -b --noCheck && vite build && node scripts/generate-sitemap.mjs",
         "lint": "eslint .",
         "optimize": "vite optimize",
         "preview": "vite preview",
@@ -64,6 +64,7 @@
         "react-error-boundary": "^6.0.0",
         "react-hook-form": "^7.54.2",
         "react-resizable-panels": "^2.1.7",
+        "react-router-dom": "^7.15.0",
         "react-to-print": "^3.1.1",
         "recharts": "^2.15.1",
         "sonner": "^2.0.1",

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <script>
+    // GitHub Pages SPA redirect: preserve path for client-side routing
+    var loc = window.location;
+    loc.replace(loc.protocol + '//' + loc.host + '/?p=' + encodeURIComponent(loc.pathname + loc.search + loc.hash));
+  </script>
+</head>
+<body></body>
+</html>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,40 @@
+# kodocalc.com — Japan Highly Skilled Professional (HSP) Visa Points Calculator
+
+## What is this site?
+kodocalc.com is a free online calculator for Japan's Highly Skilled Professional (HSP / 高度専門職) visa point system. Users input their education, work experience, salary, age, language ability, and qualifications to calculate their total points and determine eligibility for Japan's preferential immigration treatment.
+
+## Key Facts
+- 70 points or more: Eligible for HSP visa (permanent residency in 3 years)
+- 80 points or more: Eligible for expedited permanent residency (1 year)
+- Three visa categories: Academic Research (イ), Technical/Humanities (ロ), Business Management (ハ)
+- Minimum salary: ¥3,000,000 for Technical, ¥10,000,000 for Business Management
+- Points are calculated based on: Education (max 30), Work Experience (max 20-25), Salary (max 40), Age (max 15), Language (max 15), Special bonuses
+
+## Point Categories
+- Education: Doctorate (30pts), Masters (20pts), MBA (25pts), Bachelor (10pts)
+- Work Experience: 10+ years (20-25pts), 7-9 years (15-20pts), 5-6 years (10-15pts)
+- Annual Salary: ¥10M+ (40pts), ¥9M+ (35pts), ¥8M+ (30pts), ¥7M+ (25pts)
+- Age (Technical only): Under 30 (15pts), 30-34 (10pts), 35-39 (5pts)
+- Japanese Language: JLPT N1 (15pts), JLPT N2 (10pts)
+- Bonuses: Top 300 university (+10), Innovation company (+10), National license (+5-10)
+
+## HSP Visa Benefits
+1. Multiple activities allowed under one visa
+2. 5-year residence period
+3. Spouse can work without separate visa
+4. Can invite parents to Japan
+5. Can hire domestic workers
+6. Expedited permanent residency (1-3 years instead of 10)
+7. Priority immigration processing
+
+## Languages Supported
+Korean (ko), Japanese (ja), English (en), Simplified Chinese (zh-CN), Traditional Chinese (zh-TW)
+
+## Contact
+kodocalc@gmail.com
+
+## URLs
+- Calculator: https://kodocalc.com/
+- Guides: https://kodocalc.com/guide
+- Complete Visa Guide: https://kodocalc.com/guide/고도인재-비자-완벽-가이드
+- How to Increase Points: https://kodocalc.com/guide/포인트-올리는-방법

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,49 @@
+/**
+ * Build-time sitemap generator
+ * Run after vite build: node scripts/generate-sitemap.mjs
+ */
+
+const today = new Date().toISOString().split('T')[0];
+
+const staticPages = [
+  { loc: '/', changefreq: 'daily', priority: '1.0' },
+  { loc: '/?lang=ko', changefreq: 'daily', priority: '1.0' },
+  { loc: '/?lang=ja', changefreq: 'daily', priority: '0.9' },
+  { loc: '/?lang=en', changefreq: 'weekly', priority: '0.8' },
+  { loc: '/?lang=zh-cn', changefreq: 'weekly', priority: '0.7' },
+  { loc: '/?lang=zh-tw', changefreq: 'weekly', priority: '0.7' },
+  { loc: '/guide', changefreq: 'weekly', priority: '0.8' },
+];
+
+// Guide pages — add new guides here
+const guidePages = [
+  { slug: '고도인재-비자-완벽-가이드', priority: '0.9' },
+  { slug: '포인트-올리는-방법', priority: '0.9' },
+];
+
+const urls = [
+  ...staticPages.map(p => `
+  <url>
+    <loc>https://kodocalc.com${p.loc}</loc>
+    <lastmod>${today}</lastmod>
+    <changefreq>${p.changefreq}</changefreq>
+    <priority>${p.priority}</priority>
+  </url>`),
+  ...guidePages.map(g => `
+  <url>
+    <loc>https://kodocalc.com/guide/${encodeURIComponent(g.slug)}</loc>
+    <lastmod>${today}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>${g.priority}</priority>
+  </url>`),
+];
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join('\n')}
+</urlset>
+`;
+
+import { writeFileSync } from 'fs';
+writeFileSync('dist/sitemap.xml', sitemap.trim());
+console.log(`✅ sitemap.xml generated with ${staticPages.length + guidePages.length} URLs (${today})`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { Routes, Route, Link } from "react-router-dom";
 import { Header } from "@/components/Header";
 import { PointsForm } from "@/components/PointsForm";
 import { PointsResult } from "@/components/PointsResult";
@@ -16,8 +17,23 @@ import { useI18n } from '@/i18n';
 import { trackVisaTypeSelected, trackCalculationCompleted } from '@/lib/analytics';
 import { VisaCalculatorService } from '@/services';
 import { GraduationCap, Gear, Briefcase, Check, ArrowsClockwise } from "@phosphor-icons/react";
+import { GuideLayout } from "@/pages/GuideLayout";
+import { GuideIndex } from "@/pages/GuideIndex";
+import { GuidePage } from "@/pages/GuidePage";
 
 function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<CalculatorPage />} />
+      <Route path="/guide" element={<GuideLayout />}>
+        <Route index element={<GuideIndex />} />
+        <Route path=":slug" element={<GuidePage />} />
+      </Route>
+    </Routes>
+  );
+}
+
+function CalculatorPage() {
   const { t } = useI18n();
   const resultsRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+
+interface SEOHeadProps {
+  title: string;
+  description: string;
+  path: string;
+  jsonLd?: Record<string, unknown>[];
+}
+
+export function SEOHead({ title, description, path, jsonLd }: SEOHeadProps) {
+  useEffect(() => {
+    document.title = title;
+
+    const setMeta = (name: string, content: string, attr = "name") => {
+      let el = document.querySelector(`meta[${attr}="${name}"]`) as HTMLMetaElement | null;
+      if (!el) {
+        el = document.createElement("meta");
+        el.setAttribute(attr, name);
+        document.head.appendChild(el);
+      }
+      el.content = content;
+    };
+
+    const fullUrl = `https://kodocalc.com${path}`;
+
+    setMeta("description", description);
+    setMeta("og:title", title, "property");
+    setMeta("og:description", description, "property");
+    setMeta("og:url", fullUrl, "property");
+    setMeta("twitter:title", title, "property");
+    setMeta("twitter:description", description, "property");
+
+    // Update canonical
+    let canonical = document.querySelector('link[rel="canonical"]') as HTMLLinkElement | null;
+    if (!canonical) {
+      canonical = document.createElement("link");
+      canonical.rel = "canonical";
+      document.head.appendChild(canonical);
+    }
+    canonical.href = fullUrl;
+
+    // JSON-LD
+    const existingScripts = document.querySelectorAll('script[data-guide-jsonld]');
+    existingScripts.forEach((s) => s.remove());
+
+    if (jsonLd) {
+      jsonLd.forEach((schema) => {
+        const script = document.createElement("script");
+        script.type = "application/ld+json";
+        script.setAttribute("data-guide-jsonld", "true");
+        script.textContent = JSON.stringify(schema);
+        document.head.appendChild(script);
+      });
+    }
+
+    return () => {
+      document.querySelectorAll('script[data-guide-jsonld]').forEach((s) => s.remove());
+    };
+  }, [title, description, path, jsonLd]);
+
+  return null;
+}

--- a/src/content/guides.ts
+++ b/src/content/guides.ts
@@ -1,0 +1,304 @@
+export interface GuideSection {
+  title: string;
+  content: string; // HTML string
+}
+
+export interface GuideFAQ {
+  question: string;
+  answer: string;
+}
+
+export interface Guide {
+  slug: string;
+  title: string;
+  description: string;
+  keywords: string[];
+  datePublished: string;
+  dateModified: string;
+  sections: GuideSection[];
+  faq: GuideFAQ[];
+}
+
+const today = new Date().toISOString().split("T")[0];
+
+export const guides: Guide[] = [
+  {
+    slug: "고도인재-비자-완벽-가이드",
+    title: "일본 고도인재 비자(高度専門職) 완벽 가이드 2026",
+    description:
+      "일본 고도인재 비자(HSP)란 무엇인지, 포인트 계산 방법, 비자 유형별 차이, 신청 절차, 영주권 혜택까지 한 페이지에서 모두 확인하세요. 70점·80점 기준과 실제 사례를 포함한 종합 안내서입니다.",
+    keywords: ["고도인재 비자", "일본 고도인재", "고도인재비자", "HSP 비자", "고도전문직", "일본 영주권"],
+    datePublished: "2026-05-14",
+    dateModified: today,
+    sections: [
+      {
+        title: "고도인재 비자(高度専門職ビザ)란?",
+        content: `
+<p><strong>고도인재 비자(高度専門職ビザ)</strong>는 일본 법무성이 운영하는 <strong>포인트제 우대 비자</strong>입니다. 학력, 경력, 연봉, 나이, 자격증, 일본어 능력 등을 합산하여 <strong>70점 이상</strong>이면 취득할 수 있으며, <strong>80점 이상</strong>이면 최단 1년 만에 영주권 신청이 가능합니다.</p>
+<p>정식 명칭은 「高度人材に対するポイント制による出入国在留管理上の優遇制度」이며, 2012년에 도입되어 현재까지 운영되고 있습니다.</p>
+<table>
+  <thead><tr><th>구분</th><th>기준 점수</th><th>영주권 신청</th></tr></thead>
+  <tbody>
+    <tr><td>일반 고도인재</td><td>70점 이상</td><td>3년 후 가능</td></tr>
+    <tr><td>고속 영주권</td><td>80점 이상</td><td><strong>1년 후 가능</strong></td></tr>
+  </tbody>
+</table>`,
+      },
+      {
+        title: "비자 3가지 유형과 차이점",
+        content: `
+<p>고도인재 비자는 활동 내용에 따라 3가지 유형으로 나뉩니다. <strong>각 유형별로 포인트 배점이 다르므로</strong> 자신에게 유리한 유형을 선택하는 것이 중요합니다.</p>
+<table>
+  <thead><tr><th>유형</th><th>일본어 명칭</th><th>대상</th><th>연봉 최소 요건</th></tr></thead>
+  <tbody>
+    <tr><td><strong>학술연구</strong></td><td>高度学術研究活動 (イ)</td><td>대학 교수, 연구원</td><td>없음</td></tr>
+    <tr><td><strong>기술·인문</strong></td><td>高度専門・技術活動 (ロ)</td><td>엔지니어, 통번역, 디자이너</td><td>300만엔 이상</td></tr>
+    <tr><td><strong>경영·관리</strong></td><td>高度経営・管理活動 (ハ)</td><td>기업 임원, 경영자</td><td>1,000만엔 이상</td></tr>
+  </tbody>
+</table>
+<p>대부분의 한국인 직장인은 <strong>기술·인문(ロ)</strong> 유형에 해당합니다. IT 엔지니어, 마케터, 통번역사, 디자이너 등이 이 유형입니다.</p>`,
+      },
+      {
+        title: "포인트 계산 항목별 상세 배점",
+        content: `
+<p>포인트는 크게 <strong>6개 카테고리</strong>로 나뉘며, 각 항목의 최고점을 합산합니다.</p>
+
+<p><strong>① 학력 (최대 30점)</strong></p>
+<table>
+  <thead><tr><th>학력</th><th>학술연구·기술인문</th><th>경영관리</th></tr></thead>
+  <tbody>
+    <tr><td>박사</td><td>30점</td><td>20점</td></tr>
+    <tr><td>석사</td><td>20점</td><td>20점</td></tr>
+    <tr><td>MBA/MOT</td><td>25점</td><td>25점</td></tr>
+    <tr><td>학사</td><td>10점</td><td>10점</td></tr>
+    <tr><td>복수 학위 가산</td><td>+5점</td><td>+5점</td></tr>
+  </tbody>
+</table>
+
+<p><strong>② 경력 (최대 20점 / 경영관리: 25점)</strong></p>
+<table>
+  <thead><tr><th>경력 연수</th><th>학술·기술</th><th>경영관리</th></tr></thead>
+  <tbody>
+    <tr><td>10년 이상</td><td>20점</td><td>25점</td></tr>
+    <tr><td>7~9년</td><td>15점</td><td>20점</td></tr>
+    <tr><td>5~6년</td><td>10점</td><td>15점</td></tr>
+    <tr><td>3~4년</td><td>5점</td><td>10점</td></tr>
+  </tbody>
+</table>
+
+<p><strong>③ 연봉 (최대 40점)</strong></p>
+<ul>
+  <li>1,000만엔 이상: 40점</li>
+  <li>900만엔~: 35점</li>
+  <li>800만엔~: 30점</li>
+  <li>700만엔~: 25점</li>
+  <li>600만엔~: 20점</li>
+  <li>500만엔~: 15점</li>
+  <li>400만엔~: 10점</li>
+  <li>300만엔~ (기술·인문만): 5점</li>
+</ul>
+
+<p><strong>④ 나이 (최대 15점 / 기술·인문만)</strong></p>
+<ul>
+  <li>29세 이하: 15점</li>
+  <li>30~34세: 10점</li>
+  <li>35~39세: 5점</li>
+  <li>40세 이상: 0점</li>
+</ul>
+
+<p><strong>⑤ 일본어 능력 (최대 15점)</strong></p>
+<ul>
+  <li>JLPT N1 또는 BJT 480점 이상: 15점</li>
+  <li>JLPT N2 또는 BJT 400점 이상: 10점</li>
+</ul>
+
+<p><strong>⑥ 특별 가산 항목</strong></p>
+<ul>
+  <li>일본 대학 졸업: +10점</li>
+  <li>Top 300 대학 졸업: +10점</li>
+  <li>이노베이션 촉진 기업 소속: +10점</li>
+  <li>일본 국가 자격증 보유: +5~10점</li>
+</ul>
+
+<p>정확한 포인트는 <a href="https://kodocalc.com">kodocalc.com 무료 계산기</a>로 즉시 확인할 수 있습니다.</p>`,
+      },
+      {
+        title: "70점 달성을 위한 현실적인 전략",
+        content: `
+<p>가장 일반적인 한국인 직장인의 <strong>70점 달성 시나리오</strong>를 소개합니다.</p>
+
+<p><strong>시나리오 1: 석사 + 5년 경력 + 500만엔 연봉 (20대)</strong></p>
+<ul>
+  <li>학력: 석사 20점</li>
+  <li>경력: 5년 10점</li>
+  <li>연봉: 500만엔 15점</li>
+  <li>나이: 29세 이하 15점</li>
+  <li>일본어: JLPT N2 10점</li>
+  <li><strong>합계: 70점 ✅</strong></li>
+</ul>
+
+<p><strong>시나리오 2: 학사 + 10년 경력 + 700만엔 연봉 (30대)</strong></p>
+<ul>
+  <li>학력: 학사 10점</li>
+  <li>경력: 10년 20점</li>
+  <li>연봉: 700만엔 25점</li>
+  <li>나이: 30~34세 10점</li>
+  <li>일본어: JLPT N2 10점</li>
+  <li><strong>합계: 75점 ✅</strong></li>
+</ul>
+
+<p><strong>포인트를 올리는 핵심 팁:</strong></p>
+<ol>
+  <li><strong>JLPT N1 취득</strong> — N2 대비 +5점, 가장 확실한 방법</li>
+  <li><strong>연봉 협상</strong> — 100만엔 올리면 +5점 가능</li>
+  <li><strong>일본 국가자격증</strong> — IT 관련 자격증 취득으로 +5점</li>
+  <li><strong>이노베이션 기업 이직</strong> — 해당 기업 소속 시 +10점</li>
+</ol>`,
+      },
+      {
+        title: "고도인재 비자의 7대 혜택",
+        content: `
+<p>고도인재 비자로 인정받으면 다음과 같은 우대 조치를 받을 수 있습니다.</p>
+<ol>
+  <li><strong>복합적 활동 허가</strong> — 한 가지 비자로 여러 활동 가능 (예: 엔지니어이면서 강의)</li>
+  <li><strong>5년 체류 기간</strong> — 최장 5년의 체류 기간 부여</li>
+  <li><strong>배우자 취업 허가</strong> — 배우자가 별도 취업 비자 없이도 일할 수 있음</li>
+  <li><strong>부모 초청</strong> — 일정 조건 하에 본국 부모를 일본으로 초청 가능</li>
+  <li><strong>가사 도우미 고용</strong> — 외국인 가사 도우미 고용 허가</li>
+  <li><strong>영주권 신청 단축</strong> — 70점: 3년, <strong>80점: 1년</strong></li>
+  <li><strong>입국 심사 우대</strong> — 심사 처리 기간 단축</li>
+</ol>`,
+      },
+      {
+        title: "신청 절차와 필요 서류",
+        content: `
+<p>고도인재 비자는 <strong>출입국재류관리청(入管)</strong>에 신청합니다.</p>
+
+<p><strong>기본 필요 서류:</strong></p>
+<ul>
+  <li>재류자격인정증명서 교부신청서 또는 재류자격변경허가신청서</li>
+  <li>포인트 계산표 (法務省 양식)</li>
+  <li>학위증명서 (학력 포인트 증빙)</li>
+  <li>재직증명서 및 경력증명서</li>
+  <li>원천징수표 또는 급여명세서 (연봉 증빙)</li>
+  <li>JLPT/BJT 합격증 (일본어 능력 증빙)</li>
+  <li>여권 사본</li>
+  <li>증명 사진 (4cm × 3cm)</li>
+</ul>
+
+<p><strong>신청 방법:</strong></p>
+<ol>
+  <li>본인이 직접 입관에 방문하여 신청</li>
+  <li>행정서사(行政書士)에게 위탁하여 대리 신청</li>
+  <li>소속 기관을 통한 신청</li>
+</ol>
+<p>처리 기간은 통상 <strong>2주~1개월</strong>이며, 고도인재는 우선 처리됩니다.</p>`,
+      },
+    ],
+    faq: [
+      {
+        question: "고도인재 비자와 일반 취업비자(기술·인문·국제업무)의 차이는?",
+        answer:
+          "일반 취업비자는 하나의 활동만 허가되고 체류 기간이 1~5년이지만, 고도인재 비자는 복합 활동이 가능하고 배우자 취업, 부모 초청 등 특별 혜택이 있습니다. 가장 큰 차이는 영주권 신청 단축(일반 10년 → 고도인재 1~3년)입니다.",
+      },
+      {
+        question: "포인트가 70점 미만이면 어떻게 해야 하나요?",
+        answer:
+          "JLPT N1 취득(+5~15점), 연봉 인상 협상, 일본 국가자격증 취득, 이노베이션 촉진 기업 이직 등을 통해 점수를 올릴 수 있습니다. kodocalc.com 계산기의 '제안' 기능을 활용하면 가장 효율적인 점수 올리기 방법을 확인할 수 있습니다.",
+      },
+      {
+        question: "고도인재 비자로 전직(이직)이 가능한가요?",
+        answer:
+          "고도인재 비자 1호는 소속 기관에 종속됩니다. 이직 시 재류자격 변경 신청이 필요합니다. 고도인재 비자 2호(무기한)는 소속 기관에 관계없이 활동 가능합니다.",
+      },
+      {
+        question: "한국 대학 졸업도 학력 포인트를 받을 수 있나요?",
+        answer:
+          "네. 한국을 포함한 해외 대학 졸업도 학력 포인트 대상입니다. 또한 QS, THE, ARWU 세계 대학 랭킹 Top 300 이내 대학 졸업자는 +10점 보너스를 받을 수 있습니다.",
+      },
+      {
+        question: "영주권 신청 시 주의사항은?",
+        answer:
+          "세금 체납이 없어야 하고, 이직 시 14일 이내에 입관 신고 의무를 이행해야 합니다. 또한 건강보험·연금 납부 기록도 심사됩니다. 경미한 문제는 행정서사를 통해 이유서를 작성하면 해결되는 경우가 많습니다.",
+      },
+    ],
+  },
+  {
+    slug: "포인트-올리는-방법",
+    title: "고도인재 포인트를 올리는 6가지 현실적인 방법",
+    description:
+      "고도인재 비자 70점·80점에 도달하기 위한 실전 전략. JLPT, 연봉 협상, 자격증, 대학 보너스 등 가장 효과적인 포인트 향상 방법을 정리했습니다.",
+    keywords: ["고도인재 포인트", "포인트 올리기", "JLPT N1", "일본 자격증", "고도인재 70점"],
+    datePublished: "2026-05-14",
+    dateModified: today,
+    sections: [
+      {
+        title: "현재 점수 진단하기",
+        content: `
+<p>포인트를 올리려면 먼저 <strong>현재 몇 점인지 정확히 파악</strong>하는 것이 중요합니다. <a href="https://kodocalc.com">kodocalc.com 계산기</a>에서 현재 조건을 입력하면 항목별 점수와 부족한 점수를 즉시 확인할 수 있습니다.</p>
+<p>보통 <strong>5~15점 부족</strong>한 경우가 많으며, 아래 6가지 방법 중 2~3가지를 조합하면 충분히 달성 가능합니다.</p>`,
+      },
+      {
+        title: "방법 1: JLPT N1 취득 (+5~15점)",
+        content: `
+<p>가장 확실하고 본인 노력으로 달성 가능한 방법입니다.</p>
+<table>
+  <thead><tr><th>자격</th><th>점수</th><th>비고</th></tr></thead>
+  <tbody>
+    <tr><td>JLPT N1 / BJT 480+</td><td><strong>15점</strong></td><td>일본어 대학 졸업도 동일</td></tr>
+    <tr><td>JLPT N2 / BJT 400+</td><td>10점</td><td>N1 대비 5점 낮음</td></tr>
+    <tr><td>없음</td><td>0점</td><td>—</td></tr>
+  </tbody>
+</table>
+<p>현재 N2라면 N1 취득으로 <strong>+5점</strong>, 일본어 자격이 없다면 N2로 <strong>+10점</strong>, N1으로 <strong>+15점</strong>을 올릴 수 있습니다.</p>`,
+      },
+      {
+        title: "방법 2: 연봉 협상 또는 이직 (+5~15점)",
+        content: `
+<p>연봉 구간마다 5점 단위로 포인트가 올라갑니다. <strong>100만엔만 올려도 +5점</strong>이 가능합니다.</p>
+<p>이직 시에는 반드시 새 회사의 <strong>고용계약서상 연봉</strong>을 기준으로 합니다. 보너스는 계약에 명시된 경우에만 포함됩니다.</p>`,
+      },
+      {
+        title: "방법 3: 일본 국가자격증 취득 (+5~10점)",
+        content: `
+<p>IT 업종이라면 일본 IPA(情報処理推進機構)의 국가자격증이 가장 접근하기 쉽습니다.</p>
+<ul>
+  <li><strong>基本情報技術者</strong> (기본정보기술자) — 입문 레벨</li>
+  <li><strong>応用情報技術者</strong> (응용정보기술자) — 중급</li>
+  <li><strong>データベーススペシャリスト</strong> 등 고도시험 — 상급</li>
+</ul>
+<p>보유 자격증 수에 따라 1개 +5점, 2개 이상 +10점입니다.</p>`,
+      },
+      {
+        title: "방법 4: Top 300 대학 보너스 확인 (+10점)",
+        content: `
+<p>QS, THE, ARWU 세계 대학 랭킹 <strong>Top 300위 이내</strong> 대학을 졸업했다면 +10점을 받을 수 있습니다. 한국 주요 대학들이 포함되어 있으니 반드시 확인하세요.</p>
+<p>서울대, KAIST, 연세대, 고려대, 성균관대, 포항공대, 한양대 등 다수의 한국 대학이 해당됩니다.</p>`,
+      },
+      {
+        title: "방법 5: 이노베이션 촉진 기업 소속 (+10점)",
+        content: `
+<p>일본 정부가 지정한 이노베이션 촉진 기업에 소속되어 있으면 <strong>+10점</strong>을 받습니다. 대기업뿐 아니라 스타트업, 중소기업도 포함될 수 있습니다.</p>
+<p>해당 여부는 회사의 HR 부서에 확인하거나, 법무성 고시를 참조하세요.</p>`,
+      },
+      {
+        title: "방법 6: 경력 쌓기 (시간 투자)",
+        content: `
+<p>경력 연수가 늘어나면 자연스럽게 포인트가 올라갑니다. 특히 <strong>3년 → 5년, 7년 → 10년</strong> 경계에서 큰 폭으로 상승하므로, 해당 시점까지 기다리는 것도 전략입니다.</p>
+<p>다만, 나이 포인트는 반대로 줄어드므로 <strong>가능하면 빨리 신청하는 것이 유리</strong>합니다.</p>`,
+      },
+    ],
+    faq: [
+      {
+        question: "70점과 80점의 차이는 무엇인가요?",
+        answer:
+          "70점 이상이면 고도인재 비자를 받을 수 있고 3년 후 영주권 신청이 가능합니다. 80점 이상이면 1년 후 영주권 신청이 가능하여 영주권 취득 시간이 크게 단축됩니다.",
+      },
+      {
+        question: "포인트 계산은 신청 시점 기준인가요?",
+        answer:
+          "네. 포인트는 비자 신청 시점의 조건을 기준으로 계산합니다. 따라서 JLPT 합격, 연봉 인상 등이 확정된 후에 신청하는 것이 유리합니다.",
+      },
+    ],
+  },
+];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import { ErrorBoundary } from "react-error-boundary";
 
 import App from './App.tsx'
@@ -11,11 +12,20 @@ import "./index.css"
 
 import { initAnalytics } from '@/lib/analytics'
 
+// GitHub Pages SPA redirect: restore path from 404.html redirect
+const params = new URLSearchParams(window.location.search);
+const redirectPath = params.get('p');
+if (redirectPath) {
+  window.history.replaceState(null, '', redirectPath);
+}
+
 createRoot(document.getElementById('root')!).render(
   <ErrorBoundary FallbackComponent={ErrorFallback}>
-    <I18nProvider>
-      <App />
-    </I18nProvider>
+    <BrowserRouter>
+      <I18nProvider>
+        <App />
+      </I18nProvider>
+    </BrowserRouter>
   </ErrorBoundary>
 )
 

--- a/src/pages/GuideIndex.tsx
+++ b/src/pages/GuideIndex.tsx
@@ -1,0 +1,73 @@
+import { Link } from "react-router-dom";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ArrowRight } from "@phosphor-icons/react";
+import { guides } from "@/content/guides";
+import { SEOHead } from "@/components/SEOHead";
+
+export function GuideIndex() {
+  return (
+    <>
+      <SEOHead
+        title="고도인재 비자 가이드 | kodocalc.com"
+        description="일본 고도인재 비자(HSP) 신청에 필요한 모든 정보를 정리한 가이드 모음. 포인트 계산, 영주권 신청, 대학 보너스 등."
+        path="/guide"
+      />
+
+      <div className="space-y-8">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            고도인재 비자 가이드
+          </h1>
+          <p className="mt-3 text-lg text-muted-foreground leading-relaxed">
+            일본 고도인재 비자(高度専門職) 신청에 필요한 모든 정보를 한곳에 모았습니다.
+            포인트 계산부터 영주권 신청까지, 단계별로 안내합니다.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {guides.map((guide) => (
+            <Link key={guide.slug} to={`/guide/${guide.slug}`} className="group">
+              <Card className="h-full transition-all duration-200 hover:shadow-md hover:border-primary/30 group-hover:bg-primary/5">
+                <CardContent className="pt-6 space-y-3">
+                  <div className="flex items-start justify-between">
+                    <h2 className="text-lg font-semibold text-foreground group-hover:text-primary transition-colors">
+                      {guide.title}
+                    </h2>
+                    <ArrowRight size={18} className="text-muted-foreground group-hover:text-primary transition-colors mt-1 shrink-0" />
+                  </div>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    {guide.description}
+                  </p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {guide.keywords.slice(0, 3).map((kw) => (
+                      <Badge key={kw} variant="secondary" className="text-xs">
+                        {kw}
+                      </Badge>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+
+        {/* CTA to calculator */}
+        <Card className="bg-primary/5 border-primary/20">
+          <CardContent className="pt-6 text-center space-y-3">
+            <h2 className="text-xl font-semibold">지금 바로 포인트를 계산해보세요</h2>
+            <p className="text-muted-foreground">
+              학력, 경력, 연봉, 자격증 등을 입력하면 즉시 고도인재 포인트를 확인할 수 있습니다.
+            </p>
+            <Link
+              to="/"
+              className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-6 py-2.5 rounded-lg font-medium hover:bg-primary/90 transition-colors"
+            >
+              무료 포인트 계산기 →
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/src/pages/GuideLayout.tsx
+++ b/src/pages/GuideLayout.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import { Link, Outlet, useLocation } from "react-router-dom";
+import { Header } from "@/components/Header";
+import { Separator } from "@/components/ui/separator";
+import { ArrowLeft, Calculator } from "@phosphor-icons/react";
+import { useI18n } from "@/i18n";
+
+export function GuideLayout() {
+  const { t } = useI18n();
+  const location = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
+
+  return (
+    <div className="min-h-screen bg-background font-sans">
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        <Header />
+
+        <nav className="flex items-center gap-4 mb-6 text-sm">
+          <Link
+            to="/"
+            className="inline-flex items-center gap-1.5 text-muted-foreground hover:text-primary transition-colors"
+          >
+            <Calculator size={16} />
+            {t('tabs.calculator')}
+          </Link>
+          <span className="text-muted-foreground">/</span>
+          <span className="text-foreground font-medium">가이드</span>
+        </nav>
+
+        <Outlet />
+
+        <Separator className="my-8" />
+
+        <footer className="text-center text-sm text-muted-foreground space-y-2">
+          <p>© {new Date().getFullYear()} {t('app.title')}</p>
+          <div className="flex justify-center gap-4">
+            <Link to="/" className="text-primary hover:text-primary/80 transition-colors">
+              {t('tabs.calculator')}
+            </Link>
+            <Link to="/guide" className="text-primary hover:text-primary/80 transition-colors">
+              가이드
+            </Link>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/GuidePage.tsx
+++ b/src/pages/GuidePage.tsx
@@ -1,0 +1,183 @@
+import { useParams, Link, Navigate } from "react-router-dom";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { ArrowLeft, Calculator } from "@phosphor-icons/react";
+import { guides } from "@/content/guides";
+import { SEOHead } from "@/components/SEOHead";
+
+export function GuidePage() {
+  const { slug } = useParams<{ slug: string }>();
+  const guide = guides.find((g) => g.slug === slug);
+
+  if (!guide) {
+    return <Navigate to="/guide" replace />;
+  }
+
+  return (
+    <>
+      <SEOHead
+        title={`${guide.title} | kodocalc.com`}
+        description={guide.description}
+        path={`/guide/${guide.slug}`}
+        jsonLd={[
+          {
+            "@context": "https://schema.org",
+            "@type": "Article",
+            "headline": guide.title,
+            "description": guide.description,
+            "author": { "@type": "Person", "name": "Jake Kim" },
+            "publisher": { "@type": "Organization", "name": "kodocalc.com" },
+            "datePublished": guide.datePublished,
+            "dateModified": guide.dateModified,
+          },
+          ...(guide.faq.length > 0
+            ? [{
+                "@context": "https://schema.org",
+                "@type": "FAQPage",
+                "mainEntity": guide.faq.map((f) => ({
+                  "@type": "Question",
+                  "name": f.question,
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": f.answer,
+                  },
+                })),
+              }]
+            : []),
+          {
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+              { "@type": "ListItem", "position": 1, "name": "홈", "item": "https://kodocalc.com/" },
+              { "@type": "ListItem", "position": 2, "name": "가이드", "item": "https://kodocalc.com/guide" },
+              { "@type": "ListItem", "position": 3, "name": guide.title, "item": `https://kodocalc.com/guide/${guide.slug}` },
+            ],
+          },
+        ]}
+      />
+
+      <article className="prose-container">
+        {/* Header */}
+        <header className="mb-8">
+          <div className="flex flex-wrap gap-2 mb-4">
+            {guide.keywords.map((kw) => (
+              <Badge key={kw} variant="secondary" className="text-xs">{kw}</Badge>
+            ))}
+          </div>
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-foreground leading-tight">
+            {guide.title}
+          </h1>
+          <p className="mt-4 text-lg text-muted-foreground leading-relaxed">
+            {guide.description}
+          </p>
+          <div className="mt-3 text-xs text-muted-foreground">
+            최종 업데이트: {guide.dateModified}
+          </div>
+        </header>
+
+        {/* Table of Contents */}
+        {guide.sections.length > 2 && (
+          <nav className="mb-8 p-4 bg-muted/50 rounded-lg border">
+            <h2 className="text-sm font-semibold mb-3">목차</h2>
+            <ol className="space-y-1.5 text-sm">
+              {guide.sections.map((section, idx) => (
+                <li key={idx}>
+                  <a
+                    href={`#section-${idx}`}
+                    className="text-primary hover:text-primary/80 transition-colors hover:underline"
+                  >
+                    {idx + 1}. {section.title}
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </nav>
+        )}
+
+        {/* Sections */}
+        <div className="space-y-8">
+          {guide.sections.map((section, idx) => (
+            <section key={idx} id={`section-${idx}`} className="scroll-mt-20">
+              <h2 className="text-2xl font-semibold tracking-tight text-foreground mb-4">
+                {section.title}
+              </h2>
+              <div
+                className="text-foreground/90 leading-relaxed space-y-4 [&_table]:w-full [&_table]:border-collapse [&_th]:bg-muted [&_th]:p-3 [&_th]:text-left [&_th]:text-sm [&_th]:font-semibold [&_th]:border [&_td]:p-3 [&_td]:border [&_td]:text-sm [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:space-y-1.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:space-y-1.5 [&_strong]:font-semibold [&_strong]:text-foreground [&_a]:text-primary [&_a]:underline [&_a:hover]:text-primary/80"
+                dangerouslySetInnerHTML={{ __html: section.content }}
+              />
+            </section>
+          ))}
+        </div>
+
+        {/* FAQ */}
+        {guide.faq.length > 0 && (
+          <>
+            <Separator className="my-8" />
+            <section>
+              <h2 className="text-2xl font-semibold tracking-tight text-foreground mb-6">
+                자주 묻는 질문
+              </h2>
+              <div className="space-y-4">
+                {guide.faq.map((item, idx) => (
+                  <details key={idx} className="group border rounded-lg">
+                    <summary className="flex items-center justify-between cursor-pointer p-4 font-medium text-foreground hover:bg-muted/50 transition-colors rounded-lg">
+                      {item.question}
+                      <span className="text-muted-foreground group-open:rotate-180 transition-transform">▾</span>
+                    </summary>
+                    <div className="px-4 pb-4 text-muted-foreground leading-relaxed">
+                      {item.answer}
+                    </div>
+                  </details>
+                ))}
+              </div>
+            </section>
+          </>
+        )}
+
+        {/* CTA */}
+        <Card className="mt-8 bg-primary/5 border-primary/20">
+          <CardContent className="pt-6 text-center space-y-3">
+            <h2 className="text-xl font-semibold">나의 고도인재 포인트는?</h2>
+            <p className="text-muted-foreground text-sm">
+              무료 계산기로 학력·경력·연봉·자격증을 입력하면 즉시 확인할 수 있습니다.
+            </p>
+            <Link
+              to="/"
+              className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-6 py-2.5 rounded-lg font-medium hover:bg-primary/90 transition-colors"
+            >
+              <Calculator size={18} />
+              포인트 계산하기
+            </Link>
+          </CardContent>
+        </Card>
+
+        {/* Related Guides */}
+        {guides.filter((g) => g.slug !== guide.slug).length > 0 && (
+          <div className="mt-8">
+            <h3 className="text-lg font-semibold mb-4">관련 가이드</h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {guides
+                .filter((g) => g.slug !== guide.slug)
+                .slice(0, 4)
+                .map((g) => (
+                  <Link
+                    key={g.slug}
+                    to={`/guide/${g.slug}`}
+                    className="p-3 border rounded-lg hover:border-primary/30 hover:bg-primary/5 transition-all group"
+                  >
+                    <div className="font-medium text-sm group-hover:text-primary transition-colors">
+                      {g.title}
+                    </div>
+                    <div className="text-xs text-muted-foreground mt-1 line-clamp-2">
+                      {g.description}
+                    </div>
+                  </Link>
+                ))}
+            </div>
+          </div>
+        )}
+      </article>
+    </>
+  );
+}


### PR DESCRIPTION
## Changes
- **React Router**: Routes for calculator (/), guide hub (/guide), individual guides (/guide/:slug)
- **2 Guide Pages**: 고도인재 비자 완벽 가이드, 포인트 올리는 방법
- **SEO**: Dynamic meta tags, JSON-LD (Article + FAQPage + BreadcrumbList), sitemap auto-gen
- **GEO/AIO**: llms.txt for AI crawlers, structured content for AI overviews
- **SPA Routing**: 404.html fallback for GitHub Pages
- **Build**: Sitemap generation chained to build script

Targets generic keywords: 고도인재비자 (308 impressions), 고도인재 (298), 일본 고도인재 (255)