### PR TITLE
fix: PDF 출력 시 카테고리 상세 점수 자동 펼침

### DIFF
--- a/src/components/PointsResult.tsx
+++ b/src/components/PointsResult.tsx
@@ -60,6 +60,18 @@ export function PointsResult({ data }: PointsResultProps) {
           display: block !important;
           height: auto !important;
         }
+        /* Expand all accordion items (category details) in print */
+        [data-state="closed"] > [data-radix-accordion-content] {
+          display: block !important;
+          height: auto !important;
+        }
+        [data-radix-accordion-content] {
+          height: auto !important;
+        }
+        /* Hide accordion chevron arrows in print */
+        [data-radix-accordion-trigger] svg {
+          display: none !important;
+        }
       }
     `
   });

--- a/src/index.css
+++ b/src/index.css
@@ -112,4 +112,20 @@
   [data-category] {
     page-break-inside: avoid;
   }
+  /* Force all accordion items open in print */
+  [data-state="closed"] > [data-radix-accordion-content] {
+    display: block !important;
+    height: auto !important;
+  }
+  [data-radix-accordion-content] {
+    height: auto !important;
+  }
+  [data-radix-accordion-trigger] svg {
+    display: none !important;
+  }
+  /* Force all collapsibles open in print */
+  [data-state="closed"] > [data-radix-collapsible-content] {
+    display: block !important;
+    height: auto !important;
+  }
 }


### PR DESCRIPTION
PDF/인쇄 시 모든 카테고리 상세 점수가 펼쳐진 상태로 출력됩니다.

- Accordion 아이템 강제 open (data-radix-accordion-content)
- Collapsible 섹션도 강제 open
- 인쇄 시 화살표 아이콘 숨김 처리