### PR TITLE
fix: PDF 출력 시 카테고리 상세 React 상태로 펼침

### DIFF
--- a/src/components/CategoryDetailsAccordion.tsx
+++ b/src/components/CategoryDetailsAccordion.tsx
@@ -11,9 +11,10 @@ import { Badge } from "@/components/ui/badge";
 interface CategoryDetailsAccordionProps {
   data: PointsData;
   categoryPoints: Record<string, number>;
+  expandAll?: boolean;
 }
 
-export function CategoryDetailsAccordion({ data, categoryPoints }: CategoryDetailsAccordionProps) {
+export function CategoryDetailsAccordion({ data, categoryPoints, expandAll }: CategoryDetailsAccordionProps) {
   const { t } = useI18n();
 
   const getCategoryLabel = (category: string) => {
@@ -273,7 +274,11 @@ export function CategoryDetailsAccordion({ data, categoryPoints }: CategoryDetai
   return (
     <div className="space-y-2">
       <h3 className="font-medium mb-3">{t('result.categoryDetails.title')}</h3>
-      <Accordion type="multiple" className="w-full">
+      <Accordion
+        type="multiple"
+        className="w-full"
+        {...(expandAll ? { value: Object.keys(categoryPoints) } : {})}
+      >
         {Object.entries(categoryPoints).map(([category, points]) => {
           const details = categoryRenderers[category]?.() || [t('result.categoryDetails.none')];
           
@@ -302,20 +307,6 @@ export function CategoryDetailsAccordion({ data, categoryPoints }: CategoryDetai
         })}
       </Accordion>
       
-      {/* Print styles: expand all items */}
-      <style>{`
-        @media print {
-          [data-state="closed"] [data-accordion-content] {
-            display: block !important;
-            height: auto !important;
-            overflow: visible !important;
-          }
-          
-          [data-accordion-trigger] svg {
-            display: none;
-          }
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/components/PointsResult.tsx
+++ b/src/components/PointsResult.tsx
@@ -35,6 +35,8 @@ export function PointsResult({ data }: PointsResultProps) {
     // Important for mobile (iOS Safari/Android): don't update state before invoking print
     onBeforePrint: async () => {
       setIsGeneratingPDF(true);
+      // Wait for React to re-render with expanded accordions
+      await new Promise(r => setTimeout(r, 100));
     },
     onAfterPrint: async () => {
       setIsGeneratingPDF(false);
@@ -374,7 +376,7 @@ export function PointsResult({ data }: PointsResultProps) {
 
         <Separator className="my-4" />
 
-        <CategoryDetailsAccordion data={data} categoryPoints={categoryPoints} />
+        <CategoryDetailsAccordion data={data} categoryPoints={categoryPoints} expandAll={isGeneratingPDF} />
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
CSS만으로는 Radix Accordion이 DOM에서 제거한 콘텐츠를 보여줄 수 없어서, React 상태 기반으로 변경.

- CategoryDetailsAccordion에 expandAll prop 추가 (controlled accordion)
- PDF 다운로드 시 isGeneratingPDF → expandAll로 전달
- onBeforePrint에서 100ms 대기하여 React 리렌더링 보장